### PR TITLE
Handle/skip readable files, handled by previous BufNewFile handler

### DIFF
--- a/plugin/DidYouMean.vim
+++ b/plugin/DidYouMean.vim
@@ -15,6 +15,10 @@ endfunction
 
 
 function! s:didyoumean()
+    if filereadable(expand("%"))
+        " Another BufNewFile event might have handled this already.
+        return
+    endif
     try
         " as of Vim 7.4, glob() has an optional parameter to split, but not
         " everybody is using 7.4 yet


### PR DESCRIPTION
I am using the following BufNewFile autocommand to handle copy'n'pasted
files like `b/path/to/file` from e.g `git diff`:

```
au BufNewFile * nested let s:fn = expand('<afile>') |
  \ if ! filereadable(s:fn) |
  \   let s:fn = substitute(s:fn, '^\S\{-}/', '', '') |
  \   if filereadable(s:fn) |
  \     exec 'e '.s:fn.' |
  \     bd#' |
  \     redraw |
  \     echomsg 'Editing' s:fn 'instead' |
  \   endif |
  \ endif
```

So `expand("%")` is readable / exists in DidYouMean's handler already,
and should be skipped.
