### PR TITLE
Use fzf.vim to present/filter list, if available

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 DidYouMean
 ==========
 
-Vim plugin which asks for the right file to open
+Vim plugin which asks for the right file to open.
+
+Uses fzf to present/filter the list if the [fzf.vim](https://github.com/junegunn/fzf.vim) plugin is installed.
 
 Demo:
 

--- a/plugin/DidYouMean.vim
+++ b/plugin/DidYouMean.vim
@@ -34,6 +34,14 @@ function! s:didyoumean()
         return
     endtry
 
+    if exists("*fzf#run")
+        call fzf#run({
+                    \ 'source': matching_files,
+                    \ 'sink': 'e',
+                    \ 'options': '--reverse --header "Did you mean:"'
+                    \ })
+        return
+    endif
     let shown_items = ['Did you mean:']
     for i in range(1, len(matching_files))
         call add(shown_items, i.'. '.matching_files[i-1])


### PR DESCRIPTION
Redo of #11; guess GitHub didn't like my rewrite of history ;)

re: overkill, perhaps, but I find it easier to type e.g. the bit of the filename I missed off the original command than type the number matching the filename I want.